### PR TITLE
Avoid potential conflict with pak-installed libgdal-dev from system requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,10 @@ RUN rm -rf /tmp/gdal
 
 # Install pak package from CRAN and gdalraster from GitHub
 RUN R -e "install.packages('pak', repos='https://cloud.r-project.org/')" && \
-  R -e "pak::pkg_install('devtools')" && \
-  R -e "pak::pkg_install('USDAForestService/gdalraster')" 
+  R -e "pak::pkg_install('devtools')"
+ENV PKG_SYSREQS FALSE
+RUN R -e "pak::pkg_install('USDAForestService/gdalraster')" 
+ENV PKG_SYSREQS TRUE
 
 
 


### PR DESCRIPTION
By default, **pak** will `apt-get install libgdal-dev` based on gdalraster System Requirements field. This can potentially cause conflicts with the GDAL dev build. This change resolves by setting env var `PKG_SYSREQS=FALSE` before `pak::pkg_install('USDAForestService/gdalraster')`.

ref: https://pak.r-lib.org/reference/pak-config.html?q=pak-config